### PR TITLE
chore: pin teslamate stack images to running versions

### DIFF
--- a/teslamate/docker-compose.yml
+++ b/teslamate/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   teslamateapi:
-    image: tobiasehlert/teslamateapi:latest
+    image: tobiasehlert/teslamateapi:1.25.0
     restart: always
     depends_on:
       - database
@@ -19,7 +19,7 @@ services:
 
       
   teslamate:
-    image: teslamate/teslamate:latest
+    image: teslamate/teslamate:4.0.1
     restart: always
     environment:
       - ENCRYPTION_KEY=${TESLAMATE_ENCRYPTION_KEY}
@@ -46,7 +46,7 @@ services:
       - teslamate-db:/var/lib/postgresql
 
   grafana:
-    image: teslamate/grafana:latest
+    image: teslamate/grafana:3.1.0
     restart: always
     environment:
       - DATABASE_USER=${TESLAMATE_DB_USER}


### PR DESCRIPTION
## Summary
Pins TeslaMate-related images to the versions currently running on the Portainer **local** endpoint (digest-matched via Docker Hub).

| Service | Was | Now (running) |
|---------|-----|----------------|
| teslamate | `:latest` | `4.0.1` |
| grafana | `:latest` | `3.1.0` |
| teslamateapi | `:latest` | `1.25.0` |

Note: grafana is still on **3.1.0** while teslamate app is **4.0.1** (as deployed). Renovate can open follow-up bumps.

`postgres:18-trixie` and `eclipse-mosquitto:2` left as-is (already non-latest).

## Test plan
- [ ] Compose file review
- [ ] After merge, Portainer recreate should no-op pull if tags resolve to same digests
